### PR TITLE
(BUG) Only consider initialisation once

### DIFF
--- a/components/gateway/gateway.c
+++ b/components/gateway/gateway.c
@@ -39,7 +39,7 @@ struct gateway_data {
 static struct gateway_data *gateway_ctxt( void ) {
   static struct gateway_data gateway;
 
-  struct gateway_data *ctxt = NULL;
+  static struct gateway_data *ctxt = NULL;
   if( !ctxt ){
     ctxt = &gateway;
     // Initialisation?


### PR DESCRIPTION
Variable _ctxt_ must be static to only run initialisation once