### PR TITLE
[WIP] mqtt: special-case !V and avoid garbage return values

### DIFF
--- a/components/ramses-mqtt/ramses-mqtt.c
+++ b/components/ramses-mqtt/ramses-mqtt.c
@@ -259,12 +259,30 @@ static void mqtt_publish_cmd_result( struct mqtt_data *ctxt, char const *cmd, es
 //  mqtt_publish_cmd( ctxt ); // Clear CMD so we don't execute ita again
 }
 
+static void mqtt_publish_cmd_result_str( struct mqtt_data *ctxt, char const *cmd, esp_err_t err, char const *retVal ) {
+  char topic[192],data[128];
+
+  sprintf( topic, "%s/cmd/result",ctxt->topic );
+  sprintf( data, "{ \"cmd\":\"%s\", \"err\":\"%s\", \"return\":\"%s\"} ",cmd, esp_err_to_name(err),retVal ? retVal : "" );
+  esp_mqtt_client_publish( ctxt->client,topic, data, 0, 0, 0 );
+}
+
 static void mqtt_process_cmd( struct mqtt_data *ctxt, char const *data, int dataLen ) {
   if( dataLen>0 ) {
     char cmdline[128];
     sprintf( cmdline,"%.*s", dataLen,data );	// Make sure cmdline contains trailing '\0'
 
-    int retVal;
+    // MQTT clients use !V as a gateway handshake and expect an evofw3-style string.
+    if( !strcmp( cmdline, "!V" ) ) {
+      const esp_app_desc_t *app = esp_app_get_description();
+      char version[32];
+
+      sprintf( version, "# evofw3 %s", app->version );
+      mqtt_publish_cmd_result_str( ctxt, cmdline, ESP_OK, version );
+      return;
+    }
+
+    int retVal = 0;
     esp_err_t err = cmd_run( cmdline, &retVal );
 
     mqtt_publish_cmd_result( ctxt, cmdline, err, retVal );


### PR DESCRIPTION
WIP: this PR is the broader protocol/interoperability variant of the firmware-side fix.

Related WIP PRs:
- `IndaloTech/ramses_esp#41` (this PR): broader fix for upstream `ramses_esp`, including explicit MQTT `!V` handling
- `IndaloTech/ramses_esp#42`: minimal variant that only initializes `retVal` before `cmd_run()`
- `IMMRMKW/ramses_esp#1`: same broader fix for the ESP32-C6 fork where the issue was reproduced live
- `IMMRMKW/ramses_esp#2`: same minimal init-only variant for the ESP32-C6 fork
- `ramses-rf/ramses_cc#531`: bridge-side compatibility fix for already-deployed gateways

## Why this PR exists alongside #42

I wanted to separate two questions that were previously bundled together:

1. Should firmware stop leaking uninitialized/garbage integers in MQTT `cmd/result`?  
   Yes. That is the purpose of `#42`.
2. Should MQTT `!V` return a meaningful gateway identity/version string instead of relying on downstream luck/workarounds?  
   I think also yes. That is why this broader PR exists.

If maintainers only want the smallest possible correctness fix, `#42` is the narrower option.
This PR is the version I think fixes the actual interoperability contract rather than just the undefined-behavior symptom.

## Full context

I ran into this while recovering a Home Assistant system that uses `ramses_cc` over MQTT.

Observed runtime state:
- gateway was back on Wi-Fi
- LWT was `online`
- normal `rx` traffic existed on MQTT
- Home Assistant still failed to load `ramses_cc`
- logs stayed stuck on:

```text
Transport did not bind to Protocol within 60.0 secs
```

The remaining failure was the MQTT command handshake.

## Exact payload seen in the field

The reconnect handshake publishes `!V` to `.../cmd/cmd`.
The captured reply on `.../cmd/result` was:

```json
{"cmd":"!V","err":"ESP_ERR_NOT_FOUND","return":1107995988}
```

That `return` value is not meaningful version data.
It is just whatever happened to be sitting in `retVal` when the unsupported command path returned.

## Root cause

Current MQTT command flow does this for every command:
- declare `int retVal;`
- call `cmd_run(cmdline, &retVal)`
- publish `{cmd, err, return}`

That creates two separate problems:

1. `return` can be undefined/garbage on command failure because `retVal` is not initialized before `cmd_run()`.
2. `!V` is not special-cased in MQTT even though MQTT bridge clients commonly use it as a gateway identity/version handshake.

## Why init-only is not enough

The minimal variant in `#42` would probably make current `ramses_cc` recover in this specific case, because current `ramses_cc` synthesizes an evofw3 banner when it sees:

```json
{"cmd":"!V","return":0}
```

So if firmware changes only from:

```json
{"cmd":"!V","err":"ESP_ERR_NOT_FOUND","return":1107995988}
```

to:

```json
{"cmd":"!V","err":"ESP_ERR_NOT_FOUND","return":0}
```

then today’s `ramses_cc` would probably come back.

But that is still not a good `!V` protocol answer:
- `!V` is a version/identity query
- `err: ESP_ERR_NOT_FOUND` plus `return: 0` is semantically contradictory
- other MQTT clients still do not get an actual version string
- the transport still depends on a downstream workaround rather than defining a clean `!V` response

So `#42` is a valid minimal safety fix, but it still leaves `!V` effectively working by accident.

## What this PR changes

This broader variant keeps the same `retVal` initialization fix and adds explicit MQTT `!V` handling:
- special-case `!V` in `mqtt_process_cmd()`
- publish a string result for that command: `# evofw3 <firmware-version>`
- initialize `retVal` to `0` for the generic command path so unsupported commands do not publish garbage integers

## Why the extra code is needed

The extra code is not just cosmetic. It is what makes `!V` an actual version/identity response instead of a lucky side effect of current `ramses_cc` behavior.

This means:
- MQTT `!V` has a deterministic, meaningful answer
- downstream clients do not need to infer version from an error path
- the bridge no longer depends on a specific workaround in `ramses_cc`
- interoperability is better for clients other than the current Home Assistant bridge too

## Why this shape

From the existing discussion in `#39`, it sounds like the CLI output is not naturally available to the MQTT layer. This patch stays within that constraint.

Instead of trying to generalize every `!` command, it addresses only:
- the specific `!V` handshake expected by downstream MQTT bridge clients
- the undefined integer `return` value that currently leaks out on failure

## Validation

Locally validated:
- exact bad payload captured on a live gateway: `{"cmd":"!V","err":"ESP_ERR_NOT_FOUND","return":1107995988}`
- `git diff --check`

I did not run an ESP-IDF build in this shell because the toolchain is not installed here.

## Review questions

The questions I think matter most here are:
- whether `# evofw3 <version>` is the right compatibility string for MQTT `!V`
- whether `!V` should be the only special-cased MQTT command, or whether maintainers want a slightly broader command/result contract
- whether maintainers prefer the narrower safety fix in `#42` or the fuller interoperability fix here
