### PR TITLE
[WIP] mqtt: initialize retVal before cmd_run

### DIFF
--- a/components/ramses-mqtt/ramses-mqtt.c
+++ b/components/ramses-mqtt/ramses-mqtt.c
@@ -264,7 +264,7 @@ static void mqtt_process_cmd( struct mqtt_data *ctxt, char const *data, int data
     char cmdline[128];
     sprintf( cmdline,"%.*s", dataLen,data );	// Make sure cmdline contains trailing '\0'
 
-    int retVal;
+    int retVal = 0;
     esp_err_t err = cmd_run( cmdline, &retVal );
 
     mqtt_publish_cmd_result( ctxt, cmdline, err, retVal );


### PR DESCRIPTION
WIP: this is the intentionally minimal variant of the firmware-side fix.

Related PRs:
- `IndaloTech/ramses_esp#41`: broader protocol fix for this same repo that also special-cases MQTT `!V`
- `IMMRMKW/ramses_esp#1`: corresponding broader fix for the ESP32-C6 fork where this was reproduced live
- `ramses-rf/ramses_cc#531`: bridge-side compatibility fix for already-deployed gateways

## Why open this separately

During review I wanted to split two concerns that were bundled together in `#41`:

1. undefined/garbage `return` values on MQTT command failure
2. explicit MQTT handling for `!V`

This PR only addresses the first one.

## Exact failure seen in the field

A live gateway replied to MQTT `!V` with:

```json
{"cmd":"!V","err":"ESP_ERR_NOT_FOUND","return":1107995988}
```

That `return` value is not meaningful version data. It is just whatever happened to be sitting in `retVal` when the unsupported command path returned.

## Root cause

Current code does this:

- declare `int retVal;`
- call `cmd_run(cmdline, &retVal)`
- publish `{cmd, err, return}`

So when `cmd_run()` reports an error, `return` may still contain uninitialized garbage.

## What this PR changes

Only this:

```c
int retVal = 0;
```

before calling `cmd_run()`.

That means failed commands stop leaking undefined integer values into MQTT `cmd/result`.

## Why this is useful

This is the smallest possible safety/correctness fix.
It removes the undefined-behavior aspect without changing the MQTT command contract beyond making failure output deterministic.

It is also plausible that this alone would make current `ramses_cc` recover in the specific `!V` case, because current `ramses_cc` synthesizes an evofw3 banner when it sees:

```json
{"cmd":"!V","return":0}
```

So with only this patch, an unsupported `!V` would likely become:

```json
{"cmd":"!V","err":"ESP_ERR_NOT_FOUND","return":0}
```

and current `ramses_cc` would probably come back.

## Why this is not the full fix

Even if that recovery happens, it is still working by accident:

- `!V` is a version/identity query
- `err: ESP_ERR_NOT_FOUND` plus `return: 0` is semantically contradictory
- other MQTT clients still do not get an actual version string
- the protocol still depends on a downstream workaround rather than defining a clean `!V` response

That is why `#41` exists as the broader variant:
- it removes the garbage integer problem
- and it makes MQTT `!V` return a meaningful evofw3-style version string

## Validation

Locally validated:
- exact bad payload was observed on a live gateway before this change: `{"cmd":"!V","err":"ESP_ERR_NOT_FOUND","return":1107995988}`
- `git diff --check`

I did not run an ESP-IDF build in this shell because the toolchain is not installed here.
