### PR TITLE
Fix TX stall by correcting FIFO interrupt race and missed refill conditions

### DIFF
--- a/components/frame/frame.c
+++ b/components/frame/frame.c
@@ -409,7 +409,14 @@ static void tx_fifo_fill(void) {
 
     // Switch to rising edge to detect FIFO empty
     gpio_set_intr_type( CONFIG_CC_GDO0_GPIO, GPIO_INTR_POSEDGE );
+    return;
    }
+
+  if( !gpio_get_level( CONFIG_CC_GDO0_GPIO ) ) {
+    xQueueSend( tx_isr_queue, NULL, 0 );
+    ESP_LOGW( TAG, "TX refill queued follow-up event" );
+    printf("# FRAME: TX refill queued follow-up event\n");
+  }
 }
 
 //---------------------------------------------------------------------------------
@@ -430,13 +437,22 @@ static void tx_fifo_init(void) {
 }
 
 static void tx_fifo_start(void) {
+  xQueueReset( tx_isr_queue );
+
+  gpio_intr_disable( CONFIG_CC_GDO0_GPIO );
   // Falling edge for FIFO low
   gpio_set_intr_type( CONFIG_CC_GDO0_GPIO, GPIO_INTR_NEGEDGE );
+  gpio_isr_handler_add( CONFIG_CC_GDO0_GPIO, GDO0_ISR,  NULL );
+  gpio_intr_enable( CONFIG_CC_GDO0_GPIO );
 
   tx_fifo_prime();
   tx_state = TX_FIFO_FILL;
 
-  gpio_isr_handler_add( CONFIG_CC_GDO0_GPIO, GDO0_ISR,  NULL );
+  int gdo0 = gpio_get_level( CONFIG_CC_GDO0_GPIO );
+  if( !gdo0 ) {
+    xQueueSend( tx_isr_queue, NULL, 0 );
+    printf("# FRAME: tx start: synthetic refill event queued\n");
+  }
 }
 
 static void tx_fifo_work(void) {


### PR DESCRIPTION
### Description
This PR addresses a TX stall issue I’ve observed during longer runs on the [Indalo-Tech RAMSES_ESP](https://indalo-tech.onlineweb.shop/product/ramses-esp)

#### Problem
TX can occasionally stall mid-frame, leaving the system stuck in TX mode (blue LED remains on). In my setup (WiFi + MQTT enabled), this would typically occur within a few hours. When this happens, both TX and RX stop making progress.

#### Cause
The current TX FIFO refill logic depends on a GPIO interrupt (GDO0) to trigger further servicing. There are two related issues:

**Startup ordering race**
The interrupt is armed *after* TX FIFO priming. If priming crosses the FIFO threshold before the interrupt is enabled, the edge is missed and no refill is triggered.

**Edge-only progress dependency**
Even after startup, progress depends on observing a new edge. If:
- the FIFO still requires refilling
- but no new edge occurs

then no further refill is triggered and TX stalls.

#### Fix
This change addresses both issues:

**Arm the interrupt before priming**
Ensures that any threshold crossing during priming is not missed.

**Add level-based follow-up servicing**  
After each refill step:
- The current GDO0 level is checked
- If the FIFO is still below threshold, a follow-up refill event is queued

**Add startup catch-up**
After priming, the current level is checked and a synthetic refill event is queued if needed.

**Together**, these changes ensure that TX progress no longer depends solely on observing interrupt edges.

#### Results
With this change:

- I no longer observe TX stalls
- The system runs stably for extended periods (3+ days)
- Previously, stalls would occur reliably within a few hours

#### Related
I’m not entirely sure, but this commit may have been an attempt to address a similar issue:  https://github.com/IndaloTech/ramses_esp/commit/a50b2d13b223023fb6b9a2a9ad8046bfa6f67397

After my fix I reverted this commit, which has been running without any regression. I also tested this by interrupting WiFi and restarting the MQTT server randomly, the system consistently recovered correctly using the ESP32 SDK’s built-in MQTT reconnection logic.

#### Notes  
This change improves robustness within the current design while keeping the structure intact.

While working on this, it became clear that the TX path depends on a mix of interrupt edges and implicit assumptions about hardware state, which makes it somewhat fragile.

A more robust approach would be to move toward a fully explicit state machine where:

- The ISR only signals "work available"
- The task evaluates the actual hardware state
- Progress is driven by level rather than edge history

I’d be happy to explore that further if you’re open to additional PRs, but wanted to propose this minimal fix first.